### PR TITLE
format hidden code

### DIFF
--- a/mdformat_rustfmt/__init__.py
+++ b/mdformat_rustfmt/__init__.py
@@ -51,6 +51,7 @@ def _for_each_line(string: str, action: Callable[[str], str]) -> str:
 _RUSTFMT_CUSTOM_COMMENT_BLOCK_BEGIN = "//__MDFORMAT_RUSTFMT_COMMENT_BEGIN__"
 _RUSTFMT_CUSTOM_COMMENT_BLOCK_END = "//__MDFORMAT_RUSTFMT_COMMENT_END__"
 _RUSTFMT_CUSTOM_COMMENT_ESCAPE = "//__MDFORMAT_RUSTFMT_COMMENT_ESCAPE__"
+_RUSTFMT_CUSTOM_COMMENT_BLANK_LINE = "//__MDFORMAT_RUSTFMT_COMMENT_BLANK_LINE__"
 
 
 def _hide_sharp(line: str):
@@ -58,21 +59,21 @@ def _hide_sharp(line: str):
     stripped = line.strip()
 
     if stripped.startswith("#"):
+        tokens = []
+
         if not in_commented:
             in_commented = True
+            tokens.append(_RUSTFMT_CUSTOM_COMMENT_BLOCK_BEGIN)
 
-            if stripped.startswith("##"):
-                return [
-                    _RUSTFMT_CUSTOM_COMMENT_BLOCK_BEGIN,
-                    _RUSTFMT_CUSTOM_COMMENT_ESCAPE,
-                    stripped[1:],
-                ]
-            else:
-                return [_RUSTFMT_CUSTOM_COMMENT_BLOCK_BEGIN, stripped[1:]]
         if stripped.startswith("##"):
-            return [_RUSTFMT_CUSTOM_COMMENT_ESCAPE, stripped[1:]]
-        else:
-            return stripped[1:]
+            tokens.append(_RUSTFMT_CUSTOM_COMMENT_ESCAPE)
+
+        # if stripped == "#":
+        #     tokens.append(_RUSTFMT_CUSTOM_COMMENT_BLANK_LINE)
+
+        tokens.append(stripped[1:])
+
+        return tokens
 
     if in_commented:
         in_commented = False
@@ -99,6 +100,9 @@ def _unhide_sharp(line: str):
     if _RUSTFMT_CUSTOM_COMMENT_ESCAPE in line:
         next_line_escape = True
         return None
+
+    if _RUSTFMT_CUSTOM_COMMENT_BLANK_LINE in line:
+        return "#"
 
     if in_commented:
         if line.startswith("#") and next_line_escape:

--- a/mdformat_rustfmt/__init__.py
+++ b/mdformat_rustfmt/__init__.py
@@ -34,7 +34,7 @@ def format_rust(unformatted: str, _info_str: str) -> str:
         raise Exception("Failed to format Rust code\n" + formatted)
 
     in_commented = False
-    return _for_each_line(formatted, _unhide_sharp) + "\n"
+    return _for_each_line(formatted, _unhide_sharp).replace("\r", "") + "\n"
 
 
 def _for_each_line(string: str, action: Callable[[str], str]) -> str:

--- a/mdformat_rustfmt/__init__.py
+++ b/mdformat_rustfmt/__init__.py
@@ -1,6 +1,7 @@
 __version__ = "0.0.3"  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
 
 from collections.abc import Iterable
+import re
 import subprocess
 from typing import Callable
 
@@ -97,15 +98,22 @@ def _unhide_sharp(line: str):
     if _RUSTFMT_CUSTOM_COMMENT_BLOCK_BEGIN in line:
         remove_newlines = True
         in_commented = True
-        return None
+        line = re.sub(
+            re.escape(_RUSTFMT_CUSTOM_COMMENT_BLOCK_BEGIN), "", line, 1
+        ).rstrip()
+        return line or None
 
     if _RUSTFMT_CUSTOM_COMMENT_BLOCK_END in line:
         in_commented = False
-        return None
+        line = re.sub(
+            re.escape(_RUSTFMT_CUSTOM_COMMENT_BLOCK_END), "", line, 1
+        ).rstrip()
+        return line or None
 
     if _RUSTFMT_CUSTOM_COMMENT_ESCAPE in line:
         next_line_escape = True
-        return None
+        line = re.sub(re.escape(_RUSTFMT_CUSTOM_COMMENT_ESCAPE), "", line, 1).rstrip()
+        return line or None
 
     if _RUSTFMT_CUSTOM_COMMENT_BLANK_LINE in line:
         return "#"

--- a/mdformat_rustfmt/__init__.py
+++ b/mdformat_rustfmt/__init__.py
@@ -1,19 +1,20 @@
 __version__ = "0.0.3"  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
 
-import re
 import subprocess
 from typing import Callable
+from collections.abc import Iterable
+
 
 in_commented = False
 
-from collections.abc import Iterable
 
-def flatten(l):
-    for el in l:
+def flatten(deep_list):
+    for el in deep_list:
         if isinstance(el, Iterable) and not isinstance(el, (str, bytes)):
             yield from flatten(el)
         else:
             yield el
+
 
 def format_rust(unformatted: str, _info_str: str) -> str:
     global in_commented
@@ -63,7 +64,7 @@ def _hide_sharp(line: str):
             return [_RUSTFMT_CUSTOM_COMMENT_BLOCK_BEGIN, stripped[1:]]
 
         return stripped[1:]
-            
+
     if in_commented:
         in_commented = False
         return [_RUSTFMT_CUSTOM_COMMENT_BLOCK_END, stripped]

--- a/mdformat_rustfmt/__init__.py
+++ b/mdformat_rustfmt/__init__.py
@@ -17,6 +17,7 @@ def flatten(deep_list):
 
 def format_rust(unformatted: str, _info_str: str) -> str:
     global in_commented
+    global remove_newlines
 
     unformatted = _for_each_line(unformatted, _hide_sharp)
 
@@ -46,7 +47,7 @@ def _for_each_line(string: str, action: Callable[[str], str]) -> str:
 
     lines = list(flatten(lines))
 
-    lines = [x for x in lines if x != None]
+    lines = [x for x in lines if x is not None]
     return "\n".join(lines)
 
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+blank_lines_lower_bound = 1

--- a/tests/data/fixtures.md
+++ b/tests/data/fixtures.md
@@ -23,10 +23,50 @@ fn main() {
 .
 ```rust
 fn main() {
-    # let x=a();b();c();
+#   let x = a();
+#   b();
+#   c();
     let y = d();
     e();
     f();
+}
+```
+.
+
+Format hidden lines
+.
+~~~rust
+fn main() {
+  #       let x=a();b();c();
+}
+~~~
+.
+```rust
+fn main() {
+#   let x = a();
+#   b();
+#   c();
+}
+```
+.
+
+Handle empty comment lines
+.
+~~~rust
+fn main() {
+  #
+#
+    # // comment
+let s = "asdf
+## literal hash";
+}
+~~~
+.
+```rust
+fn main() {
+#   // comment
+    let s = "asdf
+## literal hash";
 }
 ```
 .

--- a/tests/data/fixtures.md
+++ b/tests/data/fixtures.md
@@ -128,7 +128,7 @@ struct Another;
 impl Another {}
 ```
 .
-Not sure
+Comment collapse does not delete lines
 .
 ~~~rust
 # fn main() -> Result<(), amethyst::Error> {

--- a/tests/data/fixtures.md
+++ b/tests/data/fixtures.md
@@ -59,6 +59,8 @@ fn main() {
     # // comment
 let s = "asdf
 ## literal hash";
+let x = 5;
+let y = 6;
 }
 ~~~
 .
@@ -67,6 +69,8 @@ fn main() {
 #   // comment
     let s = "asdf
 ## literal hash";
+    let x = 5;
+    let y = 6;
 }
 ```
 .
@@ -104,11 +108,23 @@ struct MyStruct {}
 # fn main() {}
 #
 #
+trait SomeTrait {   fn nothing() {} }
+ struct Another;
+
+ impl  Another {}
 ~~~
 .
 ```rust
 # struct Something {}
 # 
 # fn main() {}
+# 
+trait SomeTrait {
+    fn nothing() {}
+}
+
+struct Another;
+
+impl Another {}
 ```
 .

--- a/tests/data/fixtures.md
+++ b/tests/data/fixtures.md
@@ -70,3 +70,28 @@ fn main() {
 }
 ```
 .
+
+Handle hidden derive and attr statements
+.
+~~~rust
+#   #[derive(Debug)]
+struct MyStruct {}
+~~~
+.
+```rust
+# #[derive(Debug)]
+struct MyStruct {}
+```
+.
+Handle derive and attr statements
+.
+~~~rust
+#[derive(Debug)]
+struct MyStruct {}
+~~~
+.
+```rust
+#[derive(Debug)]
+struct MyStruct {}
+```
+.

--- a/tests/data/fixtures.md
+++ b/tests/data/fixtures.md
@@ -95,3 +95,20 @@ struct MyStruct {}
 struct MyStruct {}
 ```
 .
+[NIGHTLY] Preserve blank lines
+.
+~~~rust
+# struct Something {}
+#
+#
+# fn main() {}
+#
+#
+~~~
+.
+```rust
+# struct Something {}
+# 
+# fn main() {}
+```
+.

--- a/tests/data/fixtures.md
+++ b/tests/data/fixtures.md
@@ -128,3 +128,26 @@ struct Another;
 impl Another {}
 ```
 .
+Not sure
+.
+~~~rust
+# fn main() -> Result<(), amethyst::Error> {
+#   let game_data = DispatcherBuilder::default().with_bundle(
+        // inside your rendering bundle setup
+        RenderingBundle::<DefaultBackend>::new()
+            .with_plugin(RenderFlat2D::default())
+#   )?;
+#   Ok(())
+# }
+~~~
+.
+```rust
+# fn main() -> Result<(), amethyst::Error> {
+#   let game_data = DispatcherBuilder::default().with_bundle(
+        // inside your rendering bundle setup
+        RenderingBundle::<DefaultBackend>::new().with_plugin(RenderFlat2D::default()),
+#   )?;
+#   Ok(())
+# }
+```
+.

--- a/tests/test_mdformat_rustfmt.py
+++ b/tests/test_mdformat_rustfmt.py
@@ -12,6 +12,8 @@ TEST_CASES = read_fixture_file(Path(__file__).parent / "data" / "fixtures.md")
 )
 def test_fixtures(line, title, text, expected):
     """Test fixtures in tests/data/fixtures.md."""
+    if "NIGHTLY" in title:
+        pytest.skip("nightly test not supported on stable")
     md_new = mdformat.text(text, codeformatters={"rust"})
     if md_new != expected:
         print("Formatted (unexpected) Markdown below:")


### PR DESCRIPTION
This will allow hidden code to be formatted the same as not hidden.

I did not implement any configuration options so let me know if you think this opinionated default is alright.

I'm going to use this on the https://github.com/amethyst/amethyst docs.